### PR TITLE
Add a test suite for running real-life examples

### DIFF
--- a/Tests/RunExampleProlog.m
+++ b/Tests/RunExampleProlog.m
@@ -1,0 +1,37 @@
+(* ::Package:: *)
+
+If[$FrontEnd===Null,
+	verbosity=4;
+	colorPrint=Function[(WriteString["stdout","\033[1m"<>#1<>"\033[0m "<> If[TrueQ[#4],
+		"\033[1m \033[32m"<>#2<>"\033[0m \033[0;39m","\033[1m \033[31m"<>#3<>"\033[0m \033[0;39m"]<>"\n"];
+		If[!TrueQ[#4],Quit[1]])],	
+	verbosity=10;
+	colorPrint=Function[Print[Style[#1,"Text",Bold], " ", 
+		If[TrueQ[#4],Style[#2,"Text",Darker[Green],Bold],Style[#3,"Text",Red,Bold]]]];
+];
+parseExtraArguments[]:=If[StringQ[extraArgs] && extraArgs=!="",
+	If[ToExpression[extraArgs]===$Failed,
+		Print["Cannot parse extra arguments, evaluation aborted!"];	
+		If[$FrontEnd===Null,
+			Quit[1],
+			Abort
+		]
+	]
+];
+checkSkip[]:=If[Head[skip]===List,
+	skip=ToString/@skip;
+	If[MemberQ[skip,FileBaseName[exDirectory]],
+		Print["Skipping this example."];
+		Quit[]
+	]
+];
+checkMatrix[var_]:=If[!MatchQ[var,{_?MatrixQ..}],
+	Print["Cannot load the matrix aFull, evaluation aborted!"];
+	If[$FrontEnd===Null,
+		Quit[1],
+		Abort
+	]
+];
+caDirectory=ParentDirectory@ParentDirectory@exDirectory;
+caPath = FileNameJoin[{caDirectory,"src","CANONICA.m"}];
+Block[{Print=quiet},Get[caPath]];

--- a/Tests/examples.sh
+++ b/Tests/examples.sh
@@ -8,111 +8,35 @@
 
 # Checks CANONICA using real-life calculations.
 
+# Usage examples:
+
+# Tests/examples.sh math
+
+# Tests/examples.sh math "verbosity=0"
+
+# Tests/examples.sh math "secEnd=10"
+
+# Tests/examples.sh math "secEnd=10;verbosity=6;computeParallel=True;nParallelKernels=4"
+
+# Tests/examples.sh math "skip={K4Integral,SingleTopT1,SingleTopT2,VVT2,VVT1};"
+
 # Stop if any of the examples fails
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-
-
 MATH=$1
 
-# Notice that exFile can contain more elements to check different modes/sector/etc.
-# of the same example
-
-#DrellYanOneMass
-#-------------------------------------------------------------------------------
-for exFile in 'RunExample.m'
+for exName in 'MasslessdBox' 'MasslessdBoxNonPlanar' 'DrellYanOneMass' 'TripleBox' \
+'K4Integral' 'SingleTopT1' 'SingleTopT2' 'VVT2' 'VVT1' 
 
 do
   echo
   echo -e "* \c"
-  $MATH -nopromt -script ../examples/DrellYanOneMass/$exFile -run extraArgs=\"$2\"
+  $MATH -nopromt -script ../examples/"$exName"/RunExample.m -run extraArgs=\"$2\"
 done
 
-##K4Integral
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/K4Integral/$exFile
-#done
-
-##MasslessdBox
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/MasslessdBox/$exFile
-#done
-
-##MasslessdBoxNonPlanar
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/MasslessdBoxNonPlanar/$exFile
-#done
-
-##SingleTopT1
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/SingleTopT1/$exFile
-#done
-
-##SingleTopT2
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/SingleTopT2/$exFile
-#done
-
-##TripleBox
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/TripleBox/$exFile
-#done
-##-------------------------------------------------------------------------------
-
-##VVT1
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/VVT1/$exFile
-#done
-##-------------------------------------------------------------------------------
-
-##VVT2
-##-------------------------------------------------------------------------------
-#for exFile in 'RunExample.m'
-
-#do
-#  echo
-#  echo -e "* \c"
-#  $MATH -nopromt -script ../examples/VVT2/$exFile
-#done
-##-------------------------------------------------------------------------------
 
 # If we have notify-send installed, generate a notification once the test run finishes.
 if [ -x "$(command -v notify-send)" ]; then

--- a/Tests/examples.sh
+++ b/Tests/examples.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# This software is covered by the GNU General Public License 3.
+# Copyright (C) 2017-2020 Christoph Meyer
+# Copyright (C) 2019-2020 Vladyslav Shtabovenko
+
+# Description:
+
+# Checks CANONICA using real-life calculations.
+
+# Stop if any of the examples fails
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+
+
+MATH=$1
+
+# Notice that exFile can contain more elements to check different modes/sector/etc.
+# of the same example
+
+#DrellYanOneMass
+#-------------------------------------------------------------------------------
+for exFile in 'RunExample.m'
+
+do
+  echo
+  echo -e "* \c"
+  $MATH -nopromt -script ../examples/DrellYanOneMass/$exFile
+done
+
+##K4Integral
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/K4Integral/$exFile
+#done
+
+##MasslessdBox
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/MasslessdBox/$exFile
+#done
+
+##MasslessdBoxNonPlanar
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/MasslessdBoxNonPlanar/$exFile
+#done
+
+##SingleTopT1
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/SingleTopT1/$exFile
+#done
+
+##SingleTopT2
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/SingleTopT2/$exFile
+#done
+
+##TripleBox
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/TripleBox/$exFile
+#done
+##-------------------------------------------------------------------------------
+
+##VVT1
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/VVT1/$exFile
+#done
+##-------------------------------------------------------------------------------
+
+##VVT2
+##-------------------------------------------------------------------------------
+#for exFile in 'RunExample.m'
+
+#do
+#  echo
+#  echo -e "* \c"
+#  $MATH -nopromt -script ../examples/VVT2/$exFile
+#done
+##-------------------------------------------------------------------------------
+
+# If we have notify-send installed, generate a notification once the test run finishes.
+if [ -x "$(command -v notify-send)" ]; then
+  notify-send --urgency=low -i "$([ $? = 0 ] && echo sunny || echo error)" "Finished running examples for CANONICA."
+fi
+
+
+

--- a/Tests/examples.sh
+++ b/Tests/examples.sh
@@ -28,7 +28,7 @@ for exFile in 'RunExample.m'
 do
   echo
   echo -e "* \c"
-  $MATH -nopromt -script ../examples/DrellYanOneMass/$exFile
+  $MATH -nopromt -script ../examples/DrellYanOneMass/$exFile -run extraArgs=\"$2\"
 done
 
 ##K4Integral

--- a/examples/DrellYanOneMass/RunExample.m
+++ b/examples/DrellYanOneMass/RunExample.m
@@ -1,13 +1,66 @@
-Get["../../src/CANONICA.m"];
-Get["./DrellYanOneMassDEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Drell-Yan with one internal mass*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName];
+	verbosity=4;
+	colorPrint=Function[WriteString["stdout","\033[1m"<>#1<>"\033[0m "<> If[TrueQ[#4],
+		"\033[1m \033[32m"<>#2<>"\033[0m \033[0;39m","\033[1m \033[31m"<>#3<>"\033[0m \033[0;39m"]<>"\n"]],
+	
+	exDirectory=NotebookDirectory[];
+	verbosity=10;
+	colorPrint=Function[Print[Style[#1,"Text",Bold], " ", 
+		If[TrueQ[#4],Style[#2,"Text",Darker[Green],Bold],Style[#3,"Text",Red,Bold]]]];
+];
+caDirectory=ParentDirectory@ParentDirectory@exDirectory;
+caPath = FileNameJoin[{caDirectory,"src","CANONICA.m"}];
+
+
+Block[{Print=quiet},Get[caPath]];
+description="Drell-Yan with one internal mass";
+Get[FileNameJoin[{exDirectory,"DrellYanOneMassDEQ.m"}]];
+
+
+If[!MatchQ[aFull,{_?MatrixQ..}],
+	Print["Cannot load the matrix aFull, evaluation aborted!"];
+	If[$FrontEnd===Null,
+		Exit[-1],
+		Abort
+	]
+];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
+
+Print[description];
+
 
 invariants = {x, y};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 20}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m", fullResult];
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {1, 20},VerbosityLevel->verbosity];];
 
-Exit[];
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];
+
+
+

--- a/examples/DrellYanOneMass/RunExample.m
+++ b/examples/DrellYanOneMass/RunExample.m
@@ -9,49 +9,20 @@
 
 
 If[$FrontEnd===Null,
-	exDirectory=DirectoryName[$InputFileName];
-	verbosity=4;
-	colorPrint=Function[(WriteString["stdout","\033[1m"<>#1<>"\033[0m "<> If[TrueQ[#4],
-		"\033[1m \033[32m"<>#2<>"\033[0m \033[0;39m","\033[1m \033[31m"<>#3<>"\033[0m \033[0;39m"]<>"\n"];
-		If[!TrueQ[#4],Quit[1]])],	
-	exDirectory=NotebookDirectory[];
-	verbosity=10;
-	colorPrint=Function[Print[Style[#1,"Text",Bold], " ", 
-		If[TrueQ[#4],Style[#2,"Text",Darker[Green],Bold],Style[#3,"Text",Red,Bold]]]];
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
 ];
-parseExtraArguments[]:=If[StringQ[extraArgs] && extraArgs=!="",
-	If[ToExpression[extraArgs]===$Failed,
-		Print["Cannot parse extra arguments, evaluation aborted!"];	
-		If[$FrontEnd===Null,
-			Quit[1],
-			Abort
-		]
-	]
-];
-
-caDirectory=ParentDirectory@ParentDirectory@exDirectory;
-caPath = FileNameJoin[{caDirectory,"src","CANONICA.m"}];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
 
 
-Block[{Print=quiet},Get[caPath]];
-description="Drell-Yan with one internal mass";
+description="Drell-Yan with one internal mass. Time estimate: 1 min";
 Get[FileNameJoin[{exDirectory,"DrellYanOneMassDEQ.m"}]];
-
-
-If[!MatchQ[aFull,{_?MatrixQ..}],
-	Print["Cannot load the matrix aFull, evaluation aborted!"];
-	If[$FrontEnd===Null,
-		Quit[1],
-		Abort
-	]
-];
+checkMatrix[aFull];
+Print[description];
 
 
 (* ::Section:: *)
 (*Use CANONICA to find a canonical form*)
-
-
-Print[description];
 
 
 invariants = {x, y};
@@ -63,6 +34,7 @@ nParallelKernels=2;
 
 
 parseExtraArguments[];
+checkSkip[];
 
 
 $ComputeParallel=computeParallel;

--- a/examples/K4Integral/RunExample.m
+++ b/examples/K4Integral/RunExample.m
@@ -1,13 +1,54 @@
-Get["../../src/CANONICA.m"];
-Get["./K4IntegralDEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*K4 Integral*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="K4 Integral. Time estimate: 10 min";
+Get[FileNameJoin[{exDirectory,"K4IntegralDEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=4;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 4}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m", fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];

--- a/examples/MasslessdBox/RunExample.m
+++ b/examples/MasslessdBox/RunExample.m
@@ -1,13 +1,57 @@
-Get["../../src/CANONICA.m"];
-Get["./MasslessDoubleBoxDEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Massless planar double box*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Massless planar double box. Time estimate: 2 sec";
+Get[FileNameJoin[{exDirectory,"MasslessDoubleBoxDEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=7;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 7}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m", fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];
+
+
+

--- a/examples/MasslessdBoxNonPlanar/RunExample.m
+++ b/examples/MasslessdBoxNonPlanar/RunExample.m
@@ -1,13 +1,57 @@
-Get["../../src/CANONICA.m"];
-Get["./MasslessDoubleBoxNPDEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Massless non-planar double box*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Massless non-planar double box. Time estimate: 4 sec";
+Get[FileNameJoin[{exDirectory,"MasslessDoubleBoxNPDEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=11;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 11}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m", fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];
+
+
+

--- a/examples/SingleTopT1/RunExample.m
+++ b/examples/SingleTopT1/RunExample.m
@@ -1,13 +1,57 @@
-Get["../../src/CANONICA.m"];
-Get["./STT1DEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Single top-quark topology 1*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Single top-quark topology 1. Time estimate: 12 min";
+Get[FileNameJoin[{exDirectory,"STT1DEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x, y, z};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=21;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 21}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m",fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];
+
+
+

--- a/examples/SingleTopT2/RunExample.m
+++ b/examples/SingleTopT2/RunExample.m
@@ -1,13 +1,54 @@
-Get["../../src/CANONICA.m"];
-Get["./STT2DEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Single top-quark topology 2*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Single top-quark topology 2. Time estimate: 20 min";
+Get[FileNameJoin[{exDirectory,"STT2DEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x, y, z};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=21;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 21}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m",fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];

--- a/examples/TripleBox/RunExample.m
+++ b/examples/TripleBox/RunExample.m
@@ -1,13 +1,57 @@
-Get["../../src/CANONICA.m"];
-Get["./TripleBoxDEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Triple box*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Triple box. Time estimate: 2 min";
+Get[FileNameJoin[{exDirectory,"TripleBoxDEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=19;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 19}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m",fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];
+
+
+

--- a/examples/VVT1/RunExample.m
+++ b/examples/VVT1/RunExample.m
@@ -1,13 +1,54 @@
-Get["../../src/CANONICA.m"];
-Get["./VVT1DEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Vector boson pair production topology 1*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Vector boson pair production topology 1. Time estimate: 20 min";
+Get[FileNameJoin[{exDirectory,"VVT1DEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x, y, z};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=23;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 23}];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m",fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];

--- a/examples/VVT2/RunExample.m
+++ b/examples/VVT2/RunExample.m
@@ -1,14 +1,55 @@
-Get["../../src/CANONICA.m"];
-Get["./VVT2DEQ.m"];
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*Vector boson pair production topology 2*)
+
+
+(* ::Section:: *)
+(*Load CANONICA and the matrix for this example*)
+
+
+If[$FrontEnd===Null,
+	exDirectory=DirectoryName[$InputFileName],
+	exDirectory=NotebookDirectory[]
+];
+Get[FileNameJoin[{Nest[ParentDirectory,exDirectory,2],"Tests","RunExampleProlog.m"}]]
+
+
+description="Vector boson pair production topology 2. Time estimate: 15 min";
+Get[FileNameJoin[{exDirectory,"VVT2DEQ.m"}]];
+checkMatrix[aFull];
+Print[description];
+
+
+(* ::Section:: *)
+(*Use CANONICA to find a canonical form*)
+
 
 invariants = {x, y, z};
 sectorBoundaries = SectorBoundariesFromDE[aFull];
+secStart=1;
+secEnd=24;
+computeParallel=False;
+nParallelKernels=2;
 
-fullResult = 
-RecursivelyTransformSectors[aFull, invariants, sectorBoundaries, {1, 24},
-                            DDeltaNumeratorDegree->2];
 
-If[FileExistsQ["Result.m"], DeleteFile["Result.m"]];
-Save["Result.m",fullResult];
+parseExtraArguments[];
+checkSkip[];
 
-Exit[];
+
+$ComputeParallel=computeParallel;
+$NParallelKernels=nParallelKernels;
+maxMem=MaxMemoryUsed[fullResult = 
+	RecursivelyTransformSectors[aFull, invariants, 
+	sectorBoundaries, {secStart, secEnd},DDeltaNumeratorDegree->2,
+	VerbosityLevel->verbosity];];
+
+
+(* ::Section:: *)
+(*Check the final result*)
+
+
+colorPrint["Check the obtained epsilon form:","CORRECT","WRONG",
+CheckEpsForm[fullResult[[2]], invariants,ExtractIrreducibles[aFull]]];
+Print["\tCPU Time used: ", Round[N[TimeUsed[],4],0.001], " s."];
+Print["\tRAM used: ", Round[N[maxMem/10^6]], " MB"];


### PR DESCRIPTION
This test suite should make it easier to understand the impact of performance-related patches
on realistic calculations with CANONICA

Usage examples:

```
# Run all examples
Tests/examples.sh math

# Switch verbosity level to 0
Tests/examples.sh math "verbosity=0"

# Work out only the first 10 sectors in each example
Tests/examples.sh math "secEnd=10"

# Use parallelization
Tests/examples.sh math "secEnd=10;verbosity=6;computeParallel=True;nParallelKernels=4"

# Run only fast examples
Tests/examples.sh math "skip={K4Integral,SingleTopT1,SingleTopT2,VVT2,VVT1};"
```