### PR TITLE
Fix for Mathematica 13

### DIFF
--- a/src/CANONICA.m
+++ b/src/CANONICA.m
@@ -2478,7 +2478,7 @@ MinimizePrimeFactors[ratList_List] :=
 				Total@Map[Abs[p + #[[1, 2]]] &,
 				Function[facTerm,
 					Select[facTerm, ! FreeQ[#, {primeFactor, _}] &]] /@
-					facIntList /. {} -> {{primeFactor, 0}}], p]}],
+					facIntList /. {} -> {{primeFactor, 0}}], p, Integers]}],
 			primeFactors];
 
 		minPowersTotal = Total[#[[2, 1]] & /@ minSolution];


### PR DESCRIPTION
In Mathematica 13 the default domain for `Minimize` doesn't seem to be `Integers` anymore. Compare e.g.

```Mathematica
(*Mma 12.0*)
{
  Minimize[
   Abs[-5 + p] + 2*Abs[-4 + p] + 2*Abs[-2 + p] + Abs[-1 + p] + 
    2*Abs[p] + 2*Abs[1 + p] + 2*Abs[2 + p], p, Integers],
  Minimize[
   Abs[-5 + p] + 2*Abs[-4 + p] + 2*Abs[-2 + p] + Abs[-1 + p] + 
    2*Abs[p] + 2*Abs[1 + p] + 2*Abs[2 + p], p]
  } // InputForm
(*{{24, {p -> 0}}, {24, {p -> 0}}}*)
```
with

```Mathematica
(*Mma 13.0*)
{
  Minimize[
   Abs[-5 + p] + 2*Abs[-4 + p] + 2*Abs[-2 + p] + Abs[-1 + p] + 
    2*Abs[p] + 2*Abs[1 + p] + 2*Abs[2 + p], p, Integers],
  Minimize[
   Abs[-5 + p] + 2*Abs[-4 + p] + 2*Abs[-2 + p] + Abs[-1 + p] + 
    2*Abs[p] + 2*Abs[1 + p] + 2*Abs[2 + p], p]
  } // InputForm
(*{{24, {p -> 0}}, {24, {p -> 1/2}}}*)
```
This breaks `FindConstantNormalization` and makes some of the respective unit tests fail.
With this small fix everything works again.

