### PR TITLE
Speed up linear test by using the undocumented LinearQ function.

### DIFF
--- a/src/CANONICA.m
+++ b/src/CANONICA.m
@@ -2445,14 +2445,7 @@ LinearSystemSolver[parameterEquations_List, vars_List, maxLength_Integer] :=
 
 
 LinearTest[expr_] :=
-	Return[If[ Sort[Function[monomial,
-			Total[Map[Function[term, term[[2]]],
-			Select[FactorList[monomial], ! NumberQ[#1[[1]]] &]]]] /@
-		MonomialList[expr]][[-1]] > 1,
-			False,
-			True
-		]];
-
+	Internal`LinearQ[expr, Variables[expr /. Equal -> List]];
 
 MinimizePrimeFactors[ratList_List] :=
 	Module[ {facIntList, nPowersTotal, primeFactors, minSolution,


### PR DESCRIPTION
Using the ``Internal`LinearQ`` routine mentioned [here](https://mathematica.stackexchange.com/questions/805/what-are-some-useful-undocumented-mathematica-functions/103004#103004) one can roughly gain an order of magnitude speed up when 
calling `LinearTest`

```Mathematica
SetDirectory[NotebookDirectory[]];
eqs = Get["Eqs.m"];

LinearTestNew[expr_] := 
  Internal`LinearQ[expr, Variables[expr /. Equal -> List]];
LinearTestOld[expr_] := 
  Return[If[
    Sort[Function[monomial, 
         Total[Map[Function[term, term[[2]]], 
           Select[FactorList[monomial], ! NumberQ[#1[[1]]] &]]]] /@ 
        MonomialList[expr]][[-1]] > 1, False, True]];

AbsoluteTiming[LinearTestNew /@ eqs]
(*{0.0172, {True, True, True, True, True, True, True, True,*)
AbsoluteTiming[LinearTestOld /@ eqs]
(*{0.111159, {True, True, True, True, True, True, True,*)
```

[Eqs.zip](https://github.com/christophmeyer/CANONICA/files/9484350/Eqs.zip)
